### PR TITLE
Mobile 739 support dark mode

### DIFF
--- a/AccengageSampleObjc/AccengageSampleObjc/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/AccengageSampleObjc/AccengageSampleObjc/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -84,6 +84,11 @@
       "idiom" : "ipad",
       "size" : "83.5x83.5",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/AccengageSampleObjc/AccengageSampleObjc/Base.lproj/Main.storyboard
+++ b/AccengageSampleObjc/AccengageSampleObjc/Base.lproj/Main.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14269.14" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="LSD-LR-KRK">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14810.12" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="LSD-LR-KRK">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14252.5"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14766.15"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+        <capability name="iOS 13.0 system colors" minToolsVersion="11.0"/>
     </dependencies>
     <scenes>
         <!--Main View Controller-->
@@ -14,9 +13,9 @@
             <objects>
                 <collectionViewController id="zH9-Xj-pEl" customClass="MainViewController" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="Kn4-7c-ri5">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="554"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="574"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="systemGroupedBackgroundColor"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="7R8-1P-EXh">
                             <size key="itemSize" width="150" height="180"/>
                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -24,7 +23,7 @@
                             <inset key="sectionInset" minX="10" minY="10" maxX="10" maxY="10"/>
                         </collectionViewFlowLayout>
                         <cells>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" misplaced="YES" restorationIdentifier="Cell" reuseIdentifier="Cell" id="lS1-bZ-qbD">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" restorationIdentifier="Cell" reuseIdentifier="Cell" id="lS1-bZ-qbD">
                                 <rect key="frame" x="10" y="10" width="150" height="180"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -32,14 +31,13 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" tag="1" contentMode="scaleAspectFill" horizontalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="nqw-bE-J8k">
-                                            <rect key="frame" x="0.0" y="20" width="150" height="10"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="150" height="143"/>
                                         </imageView>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hU2-9Y-VXc">
-                                            <rect key="frame" x="0.0" y="30" width="150" height="37"/>
+                                            <rect key="frame" x="0.0" y="143" width="150" height="37"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BeA-ne-Ef8">
                                                     <rect key="frame" x="0.0" y="0.0" width="150" height="1"/>
-                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="FEw-Pq-x0B"/>
                                                     </constraints>
@@ -47,11 +45,10 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="134" translatesAutoresizingMaskIntoConstraints="NO" id="hb7-qK-F2Q">
                                                     <rect key="frame" x="8" y="8.5" width="134" height="20.5"/>
                                                     <fontDescription key="fontDescription" name="HelveticaNeue-Medium" family="Helvetica Neue" pointSize="17"/>
-                                                    <color key="textColor" red="0.33333333329999998" green="0.33333333329999998" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="backgroundColor" cocoaTouchSystemColor="secondarySystemGroupedBackgroundColor"/>
                                             <constraints>
                                                 <constraint firstItem="BeA-ne-Ef8" firstAttribute="top" secondItem="hU2-9Y-VXc" secondAttribute="top" id="9v9-K6-vg5"/>
                                                 <constraint firstAttribute="trailing" secondItem="hb7-qK-F2Q" secondAttribute="trailing" constant="8" id="JiC-il-5fU"/>
@@ -64,7 +61,7 @@
                                         </view>
                                     </subviews>
                                 </view>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="secondarySystemGroupedBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="hU2-9Y-VXc" firstAttribute="top" secondItem="nqw-bE-J8k" secondAttribute="bottom" id="F2U-HI-DGJ"/>
                                     <constraint firstItem="hU2-9Y-VXc" firstAttribute="leading" secondItem="lS1-bZ-qbD" secondAttribute="leadingMargin" constant="-8" id="GkY-YL-8Ew"/>
@@ -110,20 +107,19 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" allowsMultipleSelection="YES" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="d5x-c2-7Ri">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="536"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="systemGroupedBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="SimpleCell" textLabel="f06-nW-DvS" style="IBUITableViewCellStyleDefault" id="eQl-HN-DAr">
                                 <rect key="frame" x="0.0" y="55.5" width="600" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="eQl-HN-DAr" id="vjD-rC-S0y">
-                                    <rect key="frame" x="0.0" y="0.0" width="562" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="568.5" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Edit your account settings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" id="f06-nW-DvS">
-                                            <rect key="frame" x="20" y="0.0" width="542" height="43.5"/>
+                                            <rect key="frame" x="20" y="0.0" width="540.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -133,7 +129,7 @@
                                 <rect key="frame" x="0.0" y="99.5" width="600" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="bM9-J8-gn6" id="IfF-E3-kl0">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <switch opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="bRd-d9-VGa">
@@ -145,7 +141,6 @@
                                                 <constraint firstAttribute="width" secondItem="qCp-jL-CBc" secondAttribute="height" multiplier="174:7" constant="-7" id="wJd-6h-Ii2"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -166,14 +161,14 @@
                                 <rect key="frame" x="0.0" y="143.5" width="600" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="bMi-mU-wCY" id="lww-id-wfc">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" id="D8U-eR-tPq">
-                                            <rect key="frame" x="20" y="0.0" width="560" height="43.5"/>
+                                            <rect key="frame" x="20" y="0.0" width="560" height="44"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                            <color key="textColor" red="0.43529411759999997" green="0.4431372549" blue="0.47450980390000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="textColor" cocoaTouchSystemColor="systemGrayColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -210,7 +205,7 @@
             <objects>
                 <navigationController id="Uc2-Mv-laF" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="QEU-y9-c9K">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="barTintColor" red="0.17254901959999999" green="0.57647058819999997" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </navigationBar>
@@ -227,29 +222,28 @@
             <objects>
                 <tableViewController id="G2N-sM-DGt" customClass="ProductsViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="1Df-PT-GLV">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="554"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="574"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="systemGroupedBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="Cell" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="e5x-qq-BD6" detailTextLabel="gEy-PL-xTY" style="IBUITableViewCellStyleValue2" id="2ld-jn-wFc">
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2ld-jn-wFc" id="r8Z-xO-846">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Product" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="91" id="e5x-qq-BD6">
-                                            <rect key="frame" x="16" y="13" width="91" height="17.5"/>
+                                            <rect key="frame" x="16" y="14" width="91" height="17.5"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
-                                            <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="textColor" cocoaTouchSystemColor="systemBlueColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="100" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="26" id="gEy-PL-xTY">
-                                            <rect key="frame" x="113" y="13" width="25.5" height="17.5"/>
+                                            <rect key="frame" x="113" y="14" width="25.5" height="17.5"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -301,7 +295,7 @@
                     <tabBarItem key="tabBarItem" title="Demo" image="home" id="i3y-A2-j7r"/>
                     <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="jxy-L4-VgK">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="barTintColor" red="0.17254901959999999" green="0.57647058819999997" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </navigationBar>
@@ -319,7 +313,7 @@
                 <navigationController id="xCX-O7-Edd" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Inbox" image="inbox" id="abL-GZ-yLc"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="RZr-mV-Tkz">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="barTintColor" red="0.17254901959999999" green="0.57647058819999997" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </navigationBar>
@@ -340,24 +334,24 @@
                         <viewControllerLayoutGuide type="bottom" id="rGE-6y-a4O"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="qTp-zw-cUu">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="554"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="574"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelectionDuringEditing="YES" allowsMultipleSelectionDuringEditing="YES" rowHeight="85" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="Hne-QR-vCk">
-                                <rect key="frame" x="-4" y="0.0" width="383" height="510"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="sectionIndexBackgroundColor" red="0.66666666669999997" green="0.66666666669999997" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <rect key="frame" x="-4" y="0.0" width="383" height="530"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="systemGroupedBackgroundColor"/>
+                                <color key="sectionIndexBackgroundColor" cocoaTouchSystemColor="systemGroupedBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="gray" indentationWidth="10" reuseIdentifier="messageCell" id="nft-lP-hoY" customClass="InBoxMessageTableViewCell">
-                                        <rect key="frame" x="0.0" y="22" width="383" height="85"/>
+                                        <rect key="frame" x="0.0" y="28" width="383" height="85"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="nft-lP-hoY" id="tay-ID-Uwi">
-                                            <rect key="frame" x="0.0" y="0.0" width="383" height="84.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="383" height="85"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BfV-xq-PZ8">
                                                     <rect key="frame" x="7" y="6" width="3" height="73"/>
-                                                    <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" cocoaTouchSystemColor="systemBlueColor"/>
                                                     <color key="tintColor" red="0.0" green="0.47450980390000003" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="3" id="BAf-Th-yhe"/>
@@ -369,7 +363,6 @@
                                                         <constraint firstAttribute="height" constant="21" id="8Oj-RK-LJb"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="14"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Ceci est la zone dédiée à l'affichage d'un contenu InBox créé dans l'interface ..." lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="xhz-Hy-WCn">
@@ -378,7 +371,6 @@
                                                         <constraint firstAttribute="height" constant="33" id="22J-zv-xlc"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="12"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="238" translatesAutoresizingMaskIntoConstraints="NO" id="dfd-9D-GuC">
@@ -388,7 +380,6 @@
                                                         <constraint firstAttribute="height" constant="13" id="qmJ-6R-FZF"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="K7e-3m-rGK">
@@ -412,7 +403,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="backgroundColor" cocoaTouchSystemColor="secondarySystemGroupedBackgroundColor"/>
                                             <constraints>
                                                 <constraint firstAttribute="trailingMargin" secondItem="zfA-zi-Xb3" secondAttribute="trailing" constant="-8" id="15C-Jg-0Gu"/>
                                                 <constraint firstItem="max-oT-fe8" firstAttribute="leading" secondItem="K7e-3m-rGK" secondAttribute="trailing" constant="8" id="8el-se-SP1"/>
@@ -431,7 +422,6 @@
                                                 <constraint firstItem="max-oT-fe8" firstAttribute="trailing" secondItem="tay-ID-Uwi" secondAttribute="trailingMargin" id="yKT-20-jhG"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <connections>
                                             <outlet property="category" destination="zfA-zi-Xb3" id="BYM-c9-aJf"/>
                                             <outlet property="content" destination="xhz-Hy-WCn" id="PS7-7K-2xR"/>
@@ -448,7 +438,7 @@
                                 </connections>
                             </tableView>
                             <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wre-zP-O3A">
-                                <rect key="frame" x="-4" y="510" width="383" height="44"/>
+                                <rect key="frame" x="-4" y="530" width="383" height="44"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="OV4-pQ-QIA"/>
@@ -470,7 +460,7 @@
                                 </items>
                             </toolbar>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="systemGroupedBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="trailingMargin" secondItem="Wre-zP-O3A" secondAttribute="trailing" constant="-20" id="0zx-7n-1Ls"/>
                             <constraint firstAttribute="trailingMargin" secondItem="Hne-QR-vCk" secondAttribute="trailing" constant="-20" id="1UQ-Pi-NMi"/>
@@ -573,7 +563,7 @@
                         <viewControllerLayoutGuide type="bottom" id="dAG-7t-asw"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="YSo-uH-Xp6">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="536"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="556"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XWj-8p-c25">
@@ -595,7 +585,7 @@
                                             <constraint firstAttribute="height" constant="21" id="2eV-zU-0F2"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="14"/>
-                                        <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="textColor" cocoaTouchSystemColor="systemBlueColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Expéditeur" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="5Ks-Il-A1d">
@@ -604,7 +594,6 @@
                                             <constraint firstAttribute="height" constant="21" id="op0-BX-LLn"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="12"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Reçu:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="EuB-hb-zMB">
@@ -613,7 +602,6 @@
                                             <constraint firstAttribute="height" constant="21" id="aCv-Ha-n2b"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="12"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details du message" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="FuF-dK-xbX">
@@ -622,12 +610,11 @@
                                             <constraint firstAttribute="height" constant="54" id="HLy-fz-4uG"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="12"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aLu-e8-chB">
                                         <rect key="frame" x="0.0" y="154" width="600" height="1"/>
-                                        <color key="backgroundColor" red="0.82995820050000002" green="0.82995820050000002" blue="0.82995820050000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" cocoaTouchSystemColor="opaqueSeparatorColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="GBR-9D-AFp"/>
                                         </constraints>
@@ -659,7 +646,6 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstItem="FuF-dK-xbX" firstAttribute="leading" secondItem="XWj-8p-c25" secondAttribute="leading" constant="11" id="0r1-vI-IIa"/>
                                     <constraint firstItem="3R4-B7-uQ7" firstAttribute="top" secondItem="XWj-8p-c25" secondAttribute="top" id="0wu-iO-fk7"/>
@@ -686,23 +672,23 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UY3-2J-yHm">
-                                <rect key="frame" x="0.0" y="155" width="600" height="338"/>
+                                <rect key="frame" x="0.0" y="155" width="600" height="358"/>
                                 <subviews>
                                     <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Np-qO-DmD">
-                                        <rect key="frame" x="0.0" y="0.0" width="600" height="338"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="600" height="358"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </webView>
                                     <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="cVc-xR-wwK">
-                                        <rect key="frame" x="290" y="159" width="20" height="20"/>
+                                        <rect key="frame" x="290" y="169" width="20" height="20"/>
                                     </activityIndicatorView>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pC5-CX-kzw">
-                                        <rect key="frame" x="0.0" y="0.0" width="600" height="338"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="600" height="358"/>
                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     </textView>
                                 </subviews>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="secondarySystemGroupedBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="1Np-qO-DmD" firstAttribute="height" secondItem="UY3-2J-yHm" secondAttribute="height" id="0mb-Fj-mUS"/>
                                     <constraint firstItem="1Np-qO-DmD" firstAttribute="width" secondItem="UY3-2J-yHm" secondAttribute="width" id="1Xh-2j-Avw"/>
@@ -719,7 +705,7 @@
                                 </constraints>
                             </view>
                             <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fgT-Of-zvw">
-                                <rect key="frame" x="0.0" y="493" width="600" height="44"/>
+                                <rect key="frame" x="0.0" y="513" width="600" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="wyl-vg-ZkV"/>
                                 </constraints>
@@ -728,7 +714,7 @@
                                 </items>
                             </toolbar>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="systemGroupedBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="trailingMargin" secondItem="XWj-8p-c25" secondAttribute="trailing" constant="-20" id="1Z4-hP-DXm"/>
                             <constraint firstItem="fgT-Of-zvw" firstAttribute="leading" secondItem="YSo-uH-Xp6" secondAttribute="leadingMargin" constant="-20" id="3se-aF-HyY"/>

--- a/AccengageSampleObjc/AccengageSampleObjc/Controllers/Inbox/InBoxMessageTableViewCell.m
+++ b/AccengageSampleObjc/AccengageSampleObjc/Controllers/Inbox/InBoxMessageTableViewCell.m
@@ -35,15 +35,27 @@
   self.category.backgroundColor =
       [InboxTools colorForCategory:categorie];
 
-  if (msg.isRead) {
-    (self.subject).textColor = [UIColor colorWithWhite:0.4f alpha:1.0f];
-    (self.content).textColor = [UIColor colorWithWhite:0.4f alpha:1.0f];
-    (self.statusMessage).backgroundColor = [UIColor whiteColor];
-  } else {
-    (self.subject).textColor = [UIColor blackColor];
-    (self.content).textColor = [UIColor blackColor];
-    [self.statusMessage setBackgroundColor:BLUE_COLOR];
-  }
+    if (msg.isRead) {
+        if (@available(iOS 13.0, *)) {
+            (self.subject).textColor = [UIColor secondaryLabelColor];
+            (self.content).textColor = [UIColor secondaryLabelColor];
+        } else {
+            // Fallback on earlier versions
+            (self.subject).textColor = [UIColor colorWithWhite:0.4f alpha:1.0f];
+            (self.content).textColor = [UIColor colorWithWhite:0.4f alpha:1.0f];
+        }
+        (self.statusMessage).backgroundColor = [UIColor whiteColor];
+    } else {
+        if (@available(iOS 13.0, *)) {
+            (self.subject).textColor = [UIColor labelColor];
+            (self.content).textColor = [UIColor labelColor];
+        } else {
+            // Fallback on earlier versions
+            (self.subject).textColor = [UIColor blackColor];
+            (self.content).textColor = [UIColor blackColor];
+        }
+        [self.statusMessage setBackgroundColor:[UIColor systemBlueColor]];
+    }
 
   if ([msg isArchived])
     (self.statusMessage).backgroundColor = [UIColor redColor];

--- a/AccengageSampleObjc/AccengageSampleObjc/Controllers/ProductsViewController.m
+++ b/AccengageSampleObjc/AccengageSampleObjc/Controllers/ProductsViewController.m
@@ -6,6 +6,7 @@
 //
 
 #import "ProductsViewController.h"
+#import "SettingsCell.h"
 
 static NSString * const reuseIdentifier = @"Cell";
 
@@ -17,7 +18,17 @@ static NSString * const reuseIdentifier = @"Cell";
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
+    NSMutableArray *array = [[NSMutableArray alloc] init];
+    for (int i = 0; i < 100; i++)
+    {
+        NSDictionary *userName = @{cellTypeKey: @(SettingsCellTypeSample),
+                                   cellTitleKey: @"Product", cellDetailsKey:[NSString stringWithFormat:@"%d", i]};
+        [array addObject:userName];
+    }
 
+    self.settings = array;
+    
     self.accengageAlias = @"PRODUCTS";
 }
 

--- a/AccengageSampleObjc/AccengageSampleObjc/Info.plist
+++ b/AccengageSampleObjc/AccengageSampleObjc/Info.plist
@@ -22,6 +22,8 @@
 	<array>
 		<string>bma4sreceiver</string>
 	</array>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>
@@ -33,8 +35,6 @@
 			</dict>
 		</dict>
 	</dict>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string></string>
 	<key>UIBackgroundModes</key>

--- a/AccengageSampleObjc/Vendor/SCLAlertView/SCLAlertView.m
+++ b/AccengageSampleObjc/Vendor/SCLAlertView/SCLAlertView.m
@@ -247,10 +247,17 @@ SCLTimerDisplay *buttonTimer;
     [self.view addSubview:_labelTitle];
     
     // Colors
-    self.backgroundViewColor = [UIColor whiteColor];
-    _labelTitle.textColor = UIColorFromHEX(0x4D4D4D); //Dark Grey
-    _viewText.textColor = UIColorFromHEX(0x4D4D4D); //Dark Grey
-    _contentView.layer.borderColor = UIColorFromHEX(0xCCCCCC).CGColor; //Light Grey
+    if (@available(iOS 13.0, *)) {
+        self.backgroundViewColor = [UIColor tertiarySystemGroupedBackgroundColor];
+        _labelTitle.textColor = [UIColor labelColor]; //Dark Grey
+        _viewText.textColor = [UIColor labelColor]; //Dark Grey
+        _contentView.layer.borderColor = [UIColor systemGrayColor].CGColor; //Light Grey
+    } else {
+        self.backgroundViewColor = [UIColor whiteColor];
+        _labelTitle.textColor = UIColorFromHEX(0x4D4D4D); //Dark Grey
+        _viewText.textColor = UIColorFromHEX(0x4D4D4D); //Dark Grey
+        _contentView.layer.borderColor = UIColorFromHEX(0xCCCCCC).CGColor; //Light Grey
+    }
 }
 
 - (void)setupNewWindow


### PR DESCRIPTION
**What do these changes do?**
Updates all the sample app views to support iOS 13 dark mode. All the app views now are compatible with iOS 13 dark mode.

**Why are these changes necessary?**
Keep our sample app up to date.

**How did you verify these changes?**
Manual test.

**Some screenShots:**
![IMG_0242](https://user-images.githubusercontent.com/40355084/60817148-651e5400-a19b-11e9-8d5b-40783f57934b.png)
![IMG_0243](https://user-images.githubusercontent.com/40355084/60817149-651e5400-a19b-11e9-8e53-70ab6d30a0b8.png)
![IMG_0244](https://user-images.githubusercontent.com/40355084/60817150-65b6ea80-a19b-11e9-8471-f8cf292d00e2.png)
![IMG_0245](https://user-images.githubusercontent.com/40355084/60817151-65b6ea80-a19b-11e9-8bea-7b0c569ee4a4.png)
